### PR TITLE
Ensure those building lighthouse from source are on the merge interop branch

### DIFF
--- a/v2/README-Consensus-Lighthouse.md
+++ b/v2/README-Consensus-Lighthouse.md
@@ -5,6 +5,7 @@ Clone and build Lighthouse's merge interop PR:
 ```
 $ git clone git@github.com:sigp/lighthouse.git
 $ cd lighthouse
+$ git checkout merge-f2f
 $ make
 
 # Ensure `~/.cargo/bin/lighthouse` is available in you $PATH


### PR DESCRIPTION
The README was missing the step to explicitly checkout the `merge-f2f` branch which should be required to build the right version of `lighthouse`.